### PR TITLE
Added SRT input and fallback mechanism

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
-FROM savonet/liquidsoap-alpine:main
+FROM savonet/liquidsoap:main
 
-COPY ./fusion/src/radio.liq /tmp
+COPY ./fusion/src/ /fusion/src/
 
-WORKDIR /tmp
+WORKDIR /fusion/src
 
+# default configuration, override that with values from your environment
 ENV DECAY_HOST="decay" \
     DECAY_PORT="8000" \ 
     DECAY_PASSWORD="hackme" \
     DECAY_MOUNT="radio.mp3"
+
+# live input on port 8000
+EXPOSE 8000/udp
 
 ENTRYPOINT ["liquidsoap", "radio.liq"]

--- a/fusion/src/radio.liq
+++ b/fusion/src/radio.liq
@@ -1,10 +1,84 @@
-radio = mksafe(sine())
+### constants
 
-env = environment()
-host = list.assoc("DECAY_HOST", env)
-port = int_of_string(list.assoc("DECAY_PORT", env))
-password = list.assoc("DECAY_PASSWORD", env)
-mount = list.assoc("DECAY_MOUNT", env)
+RESOURCE_PATH = "resources"
+LIVE_PORT = 8000
 
-out = output.icecast(host=host, port=port, password=password)
-out(%mp3, mount=mount, radio)
+TYPE_LIVE = "live"
+TYPE_PLAYLIST = "playlist"
+
+SOURCE_CROSS_DURATION = 5.
+LIVE_BUFFER_LENGTH = 2. * SOURCE_CROSS_DURATION
+
+### utils
+
+def get_env(~default="", key) =
+  list.assoc(default=default, key, environment())
+end
+
+def resource(path) =
+  "#{RESOURCE_PATH}/#{path}"
+end
+
+def tag_type(type, _) =
+  [("type", type)]
+end
+
+### transitions
+
+def live_in(a, b) =
+  add(normalize=false, [
+      fade.out(duration=SOURCE_CROSS_DURATION, type="sin", a),
+      fade.in(duration=SOURCE_CROSS_DURATION, type="sin", b)
+    ])
+end
+
+def live_out(a, b) =
+  add(normalize=false, [
+      fade.out(duration=SOURCE_CROSS_DURATION, type="sin", a),
+      fade.in(duration=SOURCE_CROSS_DURATION, type="sin", b)
+    ])
+end
+
+# solution from https://github.com/savonet/liquidsoap/issues/746#issuecomment-667680083
+def source_transition(a, b) =
+  if a.metadata["type"] == "live" then
+    live_out(a.source, b.source)
+  elsif b.metadata["type"] == "live" then
+    live_in(a.source, b.source)
+  else
+    sequence([a.source, b.source])
+  end
+end
+
+### variables
+
+decay_host = get_env("DECAY_HOST")
+decay_port = int_of_string(get_env("DECAY_PORT"))
+decay_password = get_env("DECAY_PASSWORD")
+decay_mount = get_env("DECAY_MOUNT")
+
+music_file = resource("audio/fallback.mp3")
+
+### inputs
+
+music = single(music_file)
+music = map_metadata(tag_type(TYPE_PLAYLIST), music)
+
+live = input.srt(port=LIVE_PORT)
+live = map_metadata(tag_type(TYPE_LIVE), live)
+live = buffer(buffer=LIVE_BUFFER_LENGTH, fallible=true, live)
+
+### stream
+
+radio = fallback(track_sensitive=false, [live, music])
+radio = cross(duration=SOURCE_CROSS_DURATION, source_transition, radio)
+radio = mksafe(radio)
+
+### outputs
+
+out = output.icecast(
+  host=decay_host,
+  port=decay_port,
+  password=decay_password
+)
+out(%mp3, mount=decay_mount, radio)


### PR DESCRIPTION
- Now playing music instead of sine
- Added SRT input as live priority input 
    - command for quick testing, assuming port `8000` and some `test.mp3` file: `ffmpeg -re -i test.mp3 -f mp3 -c:a copy 'srt://localhost:8000'`
- Crossfading between live and music
- Small modification in `Dockerfile`
   - Using `debian` image instead of `alpine`, because there is a segmentation fault when trying to use SRT input (I suspect `ffmpeg` has some issues on `alpine`)
   - Changed `/tmp` workdir to `/fusion/src` - I recommend it to be the convention, every new app should have its source in `{name}/src` inside the container
   - Explicitly exposed `8000` udp port (careful: `decay` also has `8000` as default so I recommend creating `.env` in `reactor` locally and set port mappings by env vars)

Updates to `reactor` will follow after merging this. 

Closes #15 